### PR TITLE
Fix #95: Chat Session & Message CRUD — Phase A

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ This document provides essential information for AI coding agents working on the
 | Dashboard | Statistics, top contributors tracking, and recent activity for OKR goals |
 | Events | Innovation competition overlay with team formation, structured idea scoring, FAQ, and awards |
 | Authentication | JWT-based auth with member/admin role separation |
+| ChatBot | Multi-session chat with AI Agent. Hub BE owns session/message history in PostgreSQL. Agent service (`innovation_hub_agent`) is stateless. |
 
 ## Technology Stack
 
@@ -290,6 +291,13 @@ The API Contract includes a status table (Section 12) showing implementation his
 | `event_faqs` | FAQ entries per event |
 | `event_awards` | Award categories per event |
 | `event_award_teams` | Junction table linking awards to teams |
+
+### Chat Entities
+
+| Entity | Description |
+|--------|-------------|
+| `chat_sessions` | User chat sessions with AI Agent (session ID = thread_id for Agent BE tracing) |
+| `chat_messages` | Messages within sessions, role (user/assistant), sources (JSONB for wiki refs) |
 
 ### Status Workflows
 

--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -1,7 +1,7 @@
 # API CONTRACT - Innovation Hub
 
 **Version**: 1.0
-**Cập nhật**: 2026-04-27
+**Cập nhật**: 2026-05-03
 **Mục đích**: Nguồn sự thật duy nhất (Single Source of Truth) cho cả Backend và Frontend.
 
 > **Quy tắc**: Khi cần thay đổi API, sửa file này TRƯỚC, rồi cập nhật BE và FE theo.
@@ -933,6 +933,12 @@ Recipients (cho comment/reaction/vote/status_changed): Owner của target + tấ
 | DELETE /users/{id} | ❌ | ✅ |
 | POST /users/{id}/reset-password | ❌ | ✅ |
 | GET /users/{id}/stats | ✅ | ✅ |
+| POST /chat/sessions | ✅ | ✅ |
+| GET /chat/sessions | ✅ (chỉ mình) | ✅ (chỉ mình) |
+| PATCH /chat/sessions/{id} | ✅ (chỉ mình) | ✅ (chỉ mình) |
+| DELETE /chat/sessions/{id} | ✅ (chỉ mình) | ✅ (chỉ mình) |
+| GET /chat/sessions/{id}/messages | ✅ (chỉ mình) | ✅ (chỉ mình) |
+| POST /chat/sessions/{id}/message | ✅ (chỉ mình) | ✅ (chỉ mình) |
 
 ---
 
@@ -1827,3 +1833,112 @@ Problem ←──────── Room ←───── Idea ─────
 > **Độc lập**: Sau khi copy, Event Idea hoàn toàn tách biệt. Thay đổi Room Idea KHÔNG ảnh hưởng Event Idea.
 
 *Tài liệu này là nguồn sự thật duy nhất. Mọi thay đổi API phải cập nhật ở đây trước.*
+
+---
+
+## 26. CHAT (`/chat`) — ChatBot với AI Agent
+
+> **Context**: Module Chat cho phép users tạo nhiều chat session với AI Agent. History được lưu trong PostgreSQL, owned bởi Hub Backend. Agent service (`innovation_hub_agent`) là stateless — nhận full conversation history mỗi request.
+>
+> **Phase A**: Backend CRUD layer (session + message persistence). SSE streaming proxy sẽ implement ở Phase C.
+
+### SessionObject
+```json
+{
+  "id": "uuid",
+  "title": "string",
+  "created_at": "datetime",
+  "updated_at": "datetime | null"
+}
+```
+
+### MessageObject
+```json
+{
+  "id": "uuid",
+  "role": "user | assistant",
+  "content": "string",
+  "sources": "JSONB | null",
+  "created_at": "datetime"
+}
+```
+
+> **Note**:
+> - `sources`: Wiki files được AI Agent tham chiếu (chỉ có trên assistant messages).
+> - `role`: `user` (người dùng gửi) hoặc `assistant` (AI trả lời).
+
+### Database Schema
+```sql
+chat_sessions: id (UUID PK), user_id (FK→users.id), title (VARCHAR 200), created_at, updated_at
+chat_messages: id (UUID PK), session_id (FK→chat_sessions.id CASCADE), role (CHECK IN user|assistant),
+  content (TEXT), sources (JSONB nullable), created_at
+-- Indexes: chat_sessions(user_id), chat_messages(session_id, created_at)
+```
+
+### 26.1 POST `/chat/sessions` — Tạo session 🔒
+- **Status**: 201 Created
+
+**Request Body:**
+```json
+{
+  "title": "string (max 200, bắt buộc)"
+}
+```
+
+**Response:** SessionObject
+
+### 26.2 GET `/chat/sessions` — Danh sách sessions 🔒
+- **Status**: 200 OK
+- **Logic**: Trả về tất cả sessions của current user, sort theo updated_at DESC
+
+**Response:** `SessionObject[]`
+
+### 26.3 PATCH `/chat/sessions/{session_id}` — Đổi tên session 🔒
+- **Status**: 200 OK
+- **Logic**: Chỉ owner mới được đổi tên
+
+**Request Body:**
+```json
+{
+  "title": "string (max 200, bắt buộc)"
+}
+```
+
+**Response:** SessionObject
+
+### 26.4 DELETE `/chat/sessions/{session_id}` — Xóa session 🔒
+- **Status**: 204 No Content
+- **Logic**: Chỉ owner mới được xóa. Cascade xóa tất cả messages.
+
+### 26.5 GET `/chat/sessions/{session_id}/messages` — Lịch sử tin nhắn 🔒
+- **Status**: 200 OK
+- **Logic**: Chỉ owner mới được xem. Sort theo created_at ASC.
+
+**Response:** `MessageObject[]`
+
+### 26.6 POST `/chat/sessions/{session_id}/message` — Gửi tin nhắn 🔒
+- **Status**: 200 OK
+- **Condition**: Session phải thuộc current user
+- **Phase A**: Skeleton — lưu user message vào DB, trả về message object. SSE streaming sẽ implement ở Phase C.
+
+**Request Body:**
+```json
+{
+  "content": "string (bắt buộc)"
+}
+```
+
+**Response:** MessageObject
+
+---
+
+## 27. CHAT PERMISSIONS — Phân quyền Chat
+
+| Endpoint | Member | Admin |
+|----------|--------|-------|
+| POST /chat/sessions | ✅ | ✅ |
+| GET /chat/sessions | ✅ (chỉ của mình) | ✅ (chỉ của mình) |
+| PATCH /chat/sessions/{id} | ✅ (chỉ của mình) | ✅ (chỉ của mình) |
+| DELETE /chat/sessions/{id} | ✅ (chỉ của mình) | ✅ (chỉ của mình) |
+| GET /chat/sessions/{id}/messages | ✅ (chỉ của mình) | ✅ (chỉ của mình) |
+| POST /chat/sessions/{id}/message | ✅ (chỉ của mình) | ✅ (chỉ của mình) |

--- a/backend/app/application/dto/chat_dto.py
+++ b/backend/app/application/dto/chat_dto.py
@@ -1,0 +1,46 @@
+"""Chat DTOs for request/response serialization."""
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# --- Input DTOs ---
+
+class CreateSessionDTO(BaseModel):
+    """Request body for creating a chat session."""
+    title: str = Field(..., max_length=200, description="Session name")
+
+
+class RenameSessionDTO(BaseModel):
+    """Request body for renaming a chat session."""
+    title: str = Field(..., max_length=200, description="New session name")
+
+
+class SendMessageDTO(BaseModel):
+    """Request body for sending a message."""
+    content: str = Field(..., min_length=1, description="Message text")
+
+
+# --- Output DTOs ---
+
+class SessionResponseDTO(BaseModel):
+    """Response DTO for a chat session."""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    title: str
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+
+class MessageResponseDTO(BaseModel):
+    """Response DTO for a chat message."""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    role: str
+    content: str
+    sources: Optional[Dict[str, Any]] = None
+    created_at: datetime

--- a/backend/app/application/services/chat_session_service.py
+++ b/backend/app/application/services/chat_session_service.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from typing import List
 from uuid import UUID
 
+from fastapi import HTTPException, status
+
 from app.application.dto.chat_dto import (
     MessageResponseDTO,
     SendMessageDTO,
@@ -56,10 +58,8 @@ class ChatSessionService:
     ) -> SessionResponseDTO:
         session = await session_repo.get_by_id(session_id)
         if not session:
-            from fastapi import HTTPException, status
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
         if not session.is_owned_by(user_id):
-            from fastapi import HTTPException, status
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not your session")
 
         session.rename(title)
@@ -79,10 +79,8 @@ class ChatSessionService:
     ) -> None:
         session = await session_repo.get_by_id(session_id)
         if not session:
-            from fastapi import HTTPException, status
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
         if not session.is_owned_by(user_id):
-            from fastapi import HTTPException, status
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not your session")
 
         await session_repo.delete(session_id)
@@ -96,10 +94,8 @@ class ChatSessionService:
     ) -> List[MessageResponseDTO]:
         session = await session_repo.get_by_id(session_id)
         if not session:
-            from fastapi import HTTPException, status
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
         if not session.is_owned_by(user_id):
-            from fastapi import HTTPException, status
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not your session")
 
         messages = await message_repo.list_by_session(session_id)

--- a/backend/app/application/services/chat_session_service.py
+++ b/backend/app/application/services/chat_session_service.py
@@ -1,0 +1,138 @@
+"""Chat session service - use cases for chat session management."""
+from datetime import datetime
+from typing import List
+from uuid import UUID
+
+from app.application.dto.chat_dto import (
+    MessageResponseDTO,
+    SendMessageDTO,
+    SessionResponseDTO,
+)
+from app.domain.entities.chat_message import ChatMessage
+from app.domain.entities.chat_session import ChatSession
+from app.domain.value_objects.chat_role import ChatRole
+
+
+class ChatSessionService:
+    """Orchestrates chat session and message operations."""
+
+    async def create_session(
+        self,
+        session_repo,
+        user_id: UUID,
+        title: str,
+    ) -> SessionResponseDTO:
+        session = ChatSession(user_id=user_id, title=title)
+        saved = await session_repo.create(session)
+        return SessionResponseDTO(
+            id=saved.id,
+            title=saved.title,
+            created_at=saved.created_at,
+            updated_at=saved.updated_at,
+        )
+
+    async def list_sessions(
+        self,
+        session_repo,
+        user_id: UUID,
+    ) -> List[SessionResponseDTO]:
+        sessions = await session_repo.list_by_user(user_id)
+        return [
+            SessionResponseDTO(
+                id=s.id,
+                title=s.title,
+                created_at=s.created_at,
+                updated_at=s.updated_at,
+            )
+            for s in sessions
+        ]
+
+    async def rename_session(
+        self,
+        session_repo,
+        session_id: UUID,
+        user_id: UUID,
+        title: str,
+    ) -> SessionResponseDTO:
+        session = await session_repo.get_by_id(session_id)
+        if not session:
+            from fastapi import HTTPException, status
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+        if not session.is_owned_by(user_id):
+            from fastapi import HTTPException, status
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not your session")
+
+        session.rename(title)
+        updated = await session_repo.update(session)
+        return SessionResponseDTO(
+            id=updated.id,
+            title=updated.title,
+            created_at=updated.created_at,
+            updated_at=updated.updated_at,
+        )
+
+    async def delete_session(
+        self,
+        session_repo,
+        session_id: UUID,
+        user_id: UUID,
+    ) -> None:
+        session = await session_repo.get_by_id(session_id)
+        if not session:
+            from fastapi import HTTPException, status
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+        if not session.is_owned_by(user_id):
+            from fastapi import HTTPException, status
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not your session")
+
+        await session_repo.delete(session_id)
+
+    async def get_messages(
+        self,
+        session_repo,
+        message_repo,
+        session_id: UUID,
+        user_id: UUID,
+    ) -> List[MessageResponseDTO]:
+        session = await session_repo.get_by_id(session_id)
+        if not session:
+            from fastapi import HTTPException, status
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+        if not session.is_owned_by(user_id):
+            from fastapi import HTTPException, status
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not your session")
+
+        messages = await message_repo.list_by_session(session_id)
+        return [
+            MessageResponseDTO(
+                id=m.id,
+                role=m.role.value,
+                content=m.content,
+                sources=m.sources,
+                created_at=m.created_at,
+            )
+            for m in messages
+        ]
+
+    async def save_message(
+        self,
+        message_repo,
+        session_id: UUID,
+        role: ChatRole,
+        content: str,
+        sources: dict = None,
+    ) -> MessageResponseDTO:
+        message = ChatMessage(
+            session_id=session_id,
+            role=role,
+            content=content,
+            sources=sources,
+        )
+        saved = await message_repo.save(message)
+        return MessageResponseDTO(
+            id=saved.id,
+            role=saved.role.value,
+            content=saved.content,
+            sources=saved.sources,
+            created_at=saved.created_at,
+        )

--- a/backend/app/domain/entities/chat_message.py
+++ b/backend/app/domain/entities/chat_message.py
@@ -1,0 +1,28 @@
+"""ChatMessage entity - Pure business logic, no infrastructure dependencies."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Optional
+from uuid import UUID, uuid4
+
+from app.domain.value_objects.chat_role import ChatRole
+
+
+@dataclass
+class ChatMessage:
+    """Domain entity representing a message in a chat session."""
+    session_id: UUID
+    role: ChatRole
+    content: str
+    id: UUID = field(default_factory=uuid4)
+    sources: Optional[Dict[str, Any]] = None
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+    def is_user_message(self) -> bool:
+        """Check if this is a user message."""
+        return self.role == ChatRole.USER
+
+    def is_assistant_message(self) -> bool:
+        """Check if this is an assistant message."""
+        return self.role == ChatRole.ASSISTANT

--- a/backend/app/domain/entities/chat_session.py
+++ b/backend/app/domain/entities/chat_session.py
@@ -1,0 +1,25 @@
+"""ChatSession entity - Pure business logic, no infrastructure dependencies."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from uuid import UUID, uuid4
+
+
+@dataclass
+class ChatSession:
+    """Domain entity representing a chat session with the AI Agent."""
+    user_id: UUID
+    title: str
+    id: UUID = field(default_factory=uuid4)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: Optional[datetime] = None
+
+    def rename(self, title: str) -> None:
+        """Rename the session."""
+        self.title = title
+        self.updated_at = datetime.utcnow()
+
+    def is_owned_by(self, user_id: UUID) -> bool:
+        """Check if session belongs to user."""
+        return self.user_id == user_id

--- a/backend/app/domain/repositories/chat_message_repository.py
+++ b/backend/app/domain/repositories/chat_message_repository.py
@@ -1,0 +1,20 @@
+"""ChatMessage repository interface."""
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from uuid import UUID
+
+from app.domain.entities.chat_message import ChatMessage
+
+
+class ChatMessageRepository(ABC):
+    """Abstract interface for chat message persistence operations."""
+
+    @abstractmethod
+    async def save(self, message: ChatMessage) -> ChatMessage:
+        """Save a message."""
+        pass
+
+    @abstractmethod
+    async def list_by_session(self, session_id: UUID) -> List[ChatMessage]:
+        """List all messages in a session, ordered by created_at."""
+        pass

--- a/backend/app/domain/repositories/chat_session_repository.py
+++ b/backend/app/domain/repositories/chat_session_repository.py
@@ -1,0 +1,35 @@
+"""ChatSession repository interface."""
+from abc import ABC, abstractmethod
+from typing import List, Optional
+from uuid import UUID
+
+from app.domain.entities.chat_session import ChatSession
+
+
+class ChatSessionRepository(ABC):
+    """Abstract interface for chat session persistence operations."""
+
+    @abstractmethod
+    async def get_by_id(self, session_id: UUID) -> Optional[ChatSession]:
+        """Get session by ID."""
+        pass
+
+    @abstractmethod
+    async def list_by_user(self, user_id: UUID) -> List[ChatSession]:
+        """List all sessions belonging to a user."""
+        pass
+
+    @abstractmethod
+    async def create(self, session: ChatSession) -> ChatSession:
+        """Create new session."""
+        pass
+
+    @abstractmethod
+    async def update(self, session: ChatSession) -> ChatSession:
+        """Update session (e.g. rename)."""
+        pass
+
+    @abstractmethod
+    async def delete(self, session_id: UUID) -> bool:
+        """Delete session (cascade deletes messages)."""
+        pass

--- a/backend/app/domain/value_objects/chat_role.py
+++ b/backend/app/domain/value_objects/chat_role.py
@@ -1,0 +1,8 @@
+"""Chat role value object."""
+from enum import Enum
+
+
+class ChatRole(str, Enum):
+    """Role of the message sender."""
+    USER = "user"
+    ASSISTANT = "assistant"

--- a/backend/app/infrastructure/database/migrations/versions/2026_05_03_001000_add_chat_tables.py
+++ b/backend/app/infrastructure/database/migrations/versions/2026_05_03_001000_add_chat_tables.py
@@ -1,0 +1,57 @@
+"""Add chat_sessions and chat_messages tables
+
+Revision ID: add_chat_tables
+Revises: add_score_criteria_notes
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "add_chat_tables"
+down_revision = "add_score_criteria_notes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "chat_sessions",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("title", sa.String(200), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_chat_sessions_user_id", "chat_sessions", ["user_id"])
+
+    op.create_table(
+        "chat_messages",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "session_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("chat_sessions.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("role", sa.String(20), nullable=False),
+        sa.Column("content", sa.Text, nullable=False),
+        sa.Column("sources", postgresql.JSONB, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint("role IN ('user', 'assistant')", name="ck_chat_message_role"),
+    )
+    op.create_index(
+        "ix_chat_messages_session_created",
+        "chat_messages",
+        ["session_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("chat_messages")
+    op.drop_table("chat_sessions")

--- a/backend/app/infrastructure/database/models/chat_message_model.py
+++ b/backend/app/infrastructure/database/models/chat_message_model.py
@@ -1,0 +1,35 @@
+"""ChatMessage SQLAlchemy model."""
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import CheckConstraint, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.infrastructure.database.models.base import BaseModel
+
+if TYPE_CHECKING:
+    from app.infrastructure.database.models.chat_session_model import ChatSessionModel
+
+
+class ChatMessageModel(BaseModel):
+    """ChatMessage ORM model."""
+
+    __tablename__ = "chat_messages"
+    __table_args__ = (
+        CheckConstraint("role IN ('user', 'assistant')", name="ck_chat_message_role"),
+    )
+
+    session_id: Mapped[str] = mapped_column(
+        PGUUID(as_uuid=False),
+        ForeignKey("chat_sessions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    sources: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
+
+    # Relationships
+    session: Mapped["ChatSessionModel"] = relationship(
+        "ChatSessionModel", back_populates="messages"
+    )

--- a/backend/app/infrastructure/database/models/chat_session_model.py
+++ b/backend/app/infrastructure/database/models/chat_session_model.py
@@ -1,0 +1,35 @@
+"""ChatSession SQLAlchemy model."""
+from typing import TYPE_CHECKING, List, Optional
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.infrastructure.database.models.base import BaseModel
+
+if TYPE_CHECKING:
+    from app.infrastructure.database.models.user_model import UserModel
+    from app.infrastructure.database.models.chat_message_model import ChatMessageModel
+
+
+class ChatSessionModel(BaseModel):
+    """ChatSession ORM model."""
+
+    __tablename__ = "chat_sessions"
+
+    user_id: Mapped[str] = mapped_column(
+        PGUUID(as_uuid=False),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+
+    # Relationships
+    user: Mapped["UserModel"] = relationship("UserModel", back_populates="chat_sessions")
+    messages: Mapped[List["ChatMessageModel"]] = relationship(
+        "ChatMessageModel",
+        back_populates="session",
+        cascade="all, delete-orphan",
+        order_by="ChatMessageModel.created_at",
+    )

--- a/backend/app/infrastructure/database/models/user_model.py
+++ b/backend/app/infrastructure/database/models/user_model.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from app.infrastructure.database.models.reaction_model import ReactionModel
     from app.infrastructure.database.models.vote_model import VoteModel
     from app.infrastructure.database.models.event_model import EventModel
+    from app.infrastructure.database.models.chat_session_model import ChatSessionModel
 
 
 class UserModel(BaseModel):
@@ -77,5 +78,10 @@ class UserModel(BaseModel):
     events: Mapped[List["EventModel"]] = relationship(
         "EventModel",
         back_populates="creator",
+        cascade="all, delete-orphan",
+    )
+    chat_sessions: Mapped[List["ChatSessionModel"]] = relationship(
+        "ChatSessionModel",
+        back_populates="user",
         cascade="all, delete-orphan",
     )

--- a/backend/app/infrastructure/database/repositories/chat_message_repository_impl.py
+++ b/backend/app/infrastructure/database/repositories/chat_message_repository_impl.py
@@ -1,0 +1,57 @@
+"""SQLAlchemy implementation of ChatMessageRepository."""
+from typing import List
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.entities.chat_message import ChatMessage
+from app.domain.repositories.chat_message_repository import ChatMessageRepository
+from app.domain.value_objects.chat_role import ChatRole
+from app.infrastructure.database.models.chat_message_model import ChatMessageModel
+
+
+class SQLChatMessageRepository(ChatMessageRepository):
+    """SQLAlchemy implementation of ChatMessageRepository."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    def _to_entity(self, model: ChatMessageModel) -> ChatMessage:
+        """Map ORM model to domain entity."""
+        return ChatMessage(
+            id=UUID(model.id),
+            session_id=UUID(model.session_id),
+            role=ChatRole(model.role),
+            content=model.content,
+            sources=model.sources,
+            created_at=model.created_at,
+        )
+
+    def _to_model(self, entity: ChatMessage) -> ChatMessageModel:
+        """Map domain entity to ORM model."""
+        return ChatMessageModel(
+            id=str(entity.id),
+            session_id=str(entity.session_id),
+            role=entity.role.value,
+            content=entity.content,
+            sources=entity.sources,
+            created_at=entity.created_at,
+        )
+
+    async def save(self, message: ChatMessage) -> ChatMessage:
+        model = self._to_model(message)
+        self.session.add(model)
+        await self.session.flush()
+        await self.session.refresh(model)
+        await self.session.commit()
+        return self._to_entity(model)
+
+    async def list_by_session(self, session_id: UUID) -> List[ChatMessage]:
+        result = await self.session.execute(
+            select(ChatMessageModel)
+            .where(ChatMessageModel.session_id == str(session_id))
+            .order_by(ChatMessageModel.created_at.asc())
+        )
+        models = result.scalars().all()
+        return [self._to_entity(m) for m in models]

--- a/backend/app/infrastructure/database/repositories/chat_session_repository_impl.py
+++ b/backend/app/infrastructure/database/repositories/chat_session_repository_impl.py
@@ -1,0 +1,84 @@
+"""SQLAlchemy implementation of ChatSessionRepository."""
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domain.entities.chat_session import ChatSession
+from app.domain.repositories.chat_session_repository import ChatSessionRepository
+from app.infrastructure.database.models.chat_session_model import ChatSessionModel
+
+
+class SQLChatSessionRepository(ChatSessionRepository):
+    """SQLAlchemy implementation of ChatSessionRepository."""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    def _to_entity(self, model: ChatSessionModel) -> ChatSession:
+        """Map ORM model to domain entity."""
+        return ChatSession(
+            id=UUID(model.id),
+            user_id=UUID(model.user_id),
+            title=model.title,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+    def _to_model(self, entity: ChatSession) -> ChatSessionModel:
+        """Map domain entity to ORM model."""
+        return ChatSessionModel(
+            id=str(entity.id),
+            user_id=str(entity.user_id),
+            title=entity.title,
+            created_at=entity.created_at,
+            updated_at=entity.updated_at,
+        )
+
+    async def get_by_id(self, session_id: UUID) -> Optional[ChatSession]:
+        result = await self.session.execute(
+            select(ChatSessionModel).where(ChatSessionModel.id == str(session_id))
+        )
+        model = result.scalar_one_or_none()
+        return self._to_entity(model) if model else None
+
+    async def list_by_user(self, user_id: UUID) -> List[ChatSession]:
+        result = await self.session.execute(
+            select(ChatSessionModel)
+            .where(ChatSessionModel.user_id == str(user_id))
+            .order_by(ChatSessionModel.updated_at.desc().nulls_last(), ChatSessionModel.created_at.desc())
+        )
+        models = result.scalars().all()
+        return [self._to_entity(m) for m in models]
+
+    async def create(self, chat_session: ChatSession) -> ChatSession:
+        model = self._to_model(chat_session)
+        self.session.add(model)
+        await self.session.flush()
+        await self.session.refresh(model)
+        await self.session.commit()
+        return self._to_entity(model)
+
+    async def update(self, chat_session: ChatSession) -> ChatSession:
+        model = await self.session.get(ChatSessionModel, str(chat_session.id))
+        if not model:
+            raise ValueError(f"ChatSession {chat_session.id} not found")
+
+        model.title = chat_session.title
+        model.updated_at = chat_session.updated_at
+
+        await self.session.flush()
+        await self.session.refresh(model)
+        await self.session.commit()
+        return self._to_entity(model)
+
+    async def delete(self, session_id: UUID) -> bool:
+        model = await self.session.get(ChatSessionModel, str(session_id))
+        if not model:
+            return False
+
+        await self.session.delete(model)
+        await self.session.flush()
+        await self.session.commit()
+        return True

--- a/backend/app/infrastructure/web/api/deps.py
+++ b/backend/app/infrastructure/web/api/deps.py
@@ -19,6 +19,8 @@ from app.infrastructure.database.repositories.event_scoring_criteria_repository_
 from app.infrastructure.database.repositories.event_score_repository_impl import SQLEventScoreRepository
 from app.infrastructure.database.repositories.event_faq_repository_impl import SQLEventFAQRepository
 from app.infrastructure.database.repositories.event_award_repository_impl import SQLEventAwardRepository, SQLEventAwardTeamRepository
+from app.infrastructure.database.repositories.chat_session_repository_impl import SQLChatSessionRepository
+from app.infrastructure.database.repositories.chat_message_repository_impl import SQLChatMessageRepository
 from app.infrastructure.security.password import PasswordHasher
 
 
@@ -97,6 +99,14 @@ def get_event_award_repo(session: AsyncSession = Depends(get_db_session)) -> SQL
 
 def get_event_award_team_repo(session: AsyncSession = Depends(get_db_session)) -> SQLEventAwardTeamRepository:
     return SQLEventAwardTeamRepository(session)
+
+
+def get_chat_session_repo(session: AsyncSession = Depends(get_db_session)) -> SQLChatSessionRepository:
+    return SQLChatSessionRepository(session)
+
+
+def get_chat_message_repo(session: AsyncSession = Depends(get_db_session)) -> SQLChatMessageRepository:
+    return SQLChatMessageRepository(session)
 
 
 def get_password_hasher() -> PasswordHasher:

--- a/backend/app/infrastructure/web/api/v1/endpoints/chat.py
+++ b/backend/app/infrastructure/web/api/v1/endpoints/chat.py
@@ -1,0 +1,98 @@
+"""Chat endpoints."""
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+
+from app.application.dto.chat_dto import (
+    CreateSessionDTO,
+    MessageResponseDTO,
+    RenameSessionDTO,
+    SendMessageDTO,
+    SessionResponseDTO,
+)
+from app.application.services.chat_session_service import ChatSessionService
+from app.domain.value_objects.chat_role import ChatRole
+from app.infrastructure.database.repositories.chat_session_repository_impl import SQLChatSessionRepository
+from app.infrastructure.database.repositories.chat_message_repository_impl import SQLChatMessageRepository
+from app.infrastructure.security.jwt import get_current_active_user, UserResponseDTO
+from app.infrastructure.web.api import deps
+
+router = APIRouter()
+service = ChatSessionService()
+
+
+@router.post("/sessions", response_model=SessionResponseDTO, status_code=status.HTTP_201_CREATED)
+async def create_session(
+    data: CreateSessionDTO,
+    current_user: UserResponseDTO = Depends(get_current_active_user),
+    session_repo: SQLChatSessionRepository = Depends(deps.get_chat_session_repo),
+):
+    """Create a new chat session."""
+    return await service.create_session(session_repo, current_user.id, data.title)
+
+
+@router.get("/sessions", response_model=List[SessionResponseDTO])
+async def list_sessions(
+    current_user: UserResponseDTO = Depends(get_current_active_user),
+    session_repo: SQLChatSessionRepository = Depends(deps.get_chat_session_repo),
+):
+    """List current user's chat sessions."""
+    return await service.list_sessions(session_repo, current_user.id)
+
+
+@router.patch("/sessions/{session_id}", response_model=SessionResponseDTO)
+async def rename_session(
+    session_id: UUID,
+    data: RenameSessionDTO,
+    current_user: UserResponseDTO = Depends(get_current_active_user),
+    session_repo: SQLChatSessionRepository = Depends(deps.get_chat_session_repo),
+):
+    """Rename a chat session."""
+    return await service.rename_session(session_repo, session_id, current_user.id, data.title)
+
+
+@router.delete("/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_session(
+    session_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_active_user),
+    session_repo: SQLChatSessionRepository = Depends(deps.get_chat_session_repo),
+):
+    """Delete a chat session (cascade deletes messages)."""
+    await service.delete_session(session_repo, session_id, current_user.id)
+    return None
+
+
+@router.get("/sessions/{session_id}/messages", response_model=List[MessageResponseDTO])
+async def get_messages(
+    session_id: UUID,
+    current_user: UserResponseDTO = Depends(get_current_active_user),
+    session_repo: SQLChatSessionRepository = Depends(deps.get_chat_session_repo),
+    message_repo: SQLChatMessageRepository = Depends(deps.get_chat_message_repo),
+):
+    """Get message history for a session."""
+    return await service.get_messages(session_repo, message_repo, session_id, current_user.id)
+
+
+@router.post("/sessions/{session_id}/message", response_model=MessageResponseDTO)
+async def send_message(
+    session_id: UUID,
+    data: SendMessageDTO,
+    current_user: UserResponseDTO = Depends(get_current_active_user),
+    session_repo: SQLChatSessionRepository = Depends(deps.get_chat_session_repo),
+    message_repo: SQLChatMessageRepository = Depends(deps.get_chat_message_repo),
+):
+    """Send a message to a session. Skeleton for now — SSE streaming in Phase C."""
+    # Verify session exists and belongs to user
+    session = await session_repo.get_by_id(session_id)
+    if not session:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+    if not session.is_owned_by(current_user.id):
+        from fastapi import HTTPException
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not your session")
+
+    # Save user message to DB
+    return await service.save_message(
+        message_repo, session_id, ChatRole.USER, data.content
+    )

--- a/backend/app/infrastructure/web/api/v1/router.py
+++ b/backend/app/infrastructure/web/api/v1/router.py
@@ -18,6 +18,7 @@ from app.infrastructure.web.api.v1.endpoints import (
     event_dashboard,
     event_faqs,
     event_awards,
+    chat,
 )
 from app.infrastructure.web.api.v1.endpoints.reactions import (
     problem_reactions_router,
@@ -35,6 +36,7 @@ api_router.include_router(comments.router, prefix="/comments", tags=["comments"]
 api_router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])
 api_router.include_router(uploads.router, prefix="/uploads", tags=["uploads"])
 api_router.include_router(notifications.router, prefix="/notifications", tags=["notifications"])
+api_router.include_router(chat.router, prefix="/chat", tags=["chat"])
 api_router.include_router(events.router, prefix="/events", tags=["events"])
 
 # Event team sub-routes (nested under events)


### PR DESCRIPTION
## Summary
- Implement foundational chat backend for Innovation Hub: session management and message persistence in PostgreSQL with full Clean Architecture compliance
- 6 REST API endpoints under `/api/v1/chat/` (create/list/rename/delete session, send message, get message history)
- User isolation enforced — users can only access their own sessions
- Updated `API_CONTRACT.md` (sections 26-27) and `AGENTS.md`

## Changes
| Layer | Files |
|-------|-------|
| Domain | `ChatSession`, `ChatMessage` entities, `ChatRole` enum |
| Database | `ChatSessionModel`, `ChatMessageModel` (SQLAlchemy), Alembic migration |
| Repositories | `ChatSessionRepository`, `ChatMessageRepository` (interface + SQL impl) |
| Application | `chat_dto.py` (DTOs), `ChatSessionService` |
| API | `chat.py` endpoint module, registered in router + deps |
| Docs | `API_CONTRACT.md`, `AGENTS.md` |

## Test plan
- [x] `docker-compose up -d --build` — migration auto-applied, server starts
- [x] POST `/chat/sessions` — 201 Created
- [x] GET `/chat/sessions` — 200, returns user's sessions
- [x] PATCH `/chat/sessions/{id}` — 200, rename works
- [x] POST `/chat/sessions/{id}/message` — 200, saves user message
- [x] GET `/chat/sessions/{id}/messages` — 200, returns message history
- [x] DELETE `/chat/sessions/{id}` — 204, cascade deletes messages
- [ ] Cross-user isolation (user A cannot access user B's sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)