### PR TITLE
feat: SSE Proxy & Agent Gateway Integration (Phase C, #96)

### DIFF
--- a/backend/app/application/services/agent_proxy_service.py
+++ b/backend/app/application/services/agent_proxy_service.py
@@ -1,0 +1,85 @@
+"""Agent proxy service — streams SSE from Agent BE via httpx."""
+import json
+import logging
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+import httpx
+
+from app.core.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+class AgentProxyService:
+    """Manages HTTP connection to Agent BE and streams SSE responses."""
+
+    def __init__(self) -> None:
+        settings = get_settings()
+        self._base_url = settings.agent_base_url.rstrip("/")
+        self._api_key = settings.agent_api_key
+        self._timeout = httpx.Timeout(
+            connect=10.0,
+            read=settings.agent_timeout,
+            write=10.0,
+            pool=10.0,
+        )
+        self._client: Optional[httpx.AsyncClient] = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+        return self._client
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+
+    async def stream_chat(
+        self,
+        messages: List[Dict[str, str]],
+        thread_id: Optional[str] = None,
+        user_metadata: Optional[Dict[str, Any]] = None,
+    ) -> AsyncGenerator[str, None]:
+        """Stream SSE events from Agent BE.
+
+        Yields raw SSE lines so the caller can forward them directly.
+        On connection/timeout errors, yields an SSE error line instead.
+        """
+        client = self._get_client()
+        url = f"{self._base_url}/api/chat/stream"
+        headers = {
+            "X-API-Key": self._api_key,
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+        }
+        body = {
+            "messages": messages,
+            "thread_id": thread_id or "",
+            "user_metadata": user_metadata or {},
+        }
+
+        try:
+            async with client.stream("POST", url, json=body, headers=headers) as response:
+                if response.status_code != 200:
+                    error_body = await response.aread()
+                    logger.error(
+                        "Agent BE returned %s: %s",
+                        response.status_code,
+                        error_body.decode(errors="replace"),
+                    )
+                    yield _sse_error(f"Agent service error: HTTP {response.status_code}")
+                    return
+
+                async for line in response.aiter_lines():
+                    yield line
+
+        except httpx.ConnectError as exc:
+            logger.error("Cannot connect to Agent BE at %s: %s", url, exc)
+            yield _sse_error("Agent service is unavailable. Please try again later.")
+        except httpx.ReadTimeout as exc:
+            logger.error("Agent BE timed out: %s", exc)
+            yield _sse_error("Agent service timed out. Please try again.")
+
+
+def _sse_error(message: str) -> str:
+    return f"data: {json.dumps({'type': 'error', 'content': message})}\n\n"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -43,6 +43,11 @@ class Settings(BaseSettings):
     minio_bucket: str = "avatars"
     minio_public_url: str = ""  # External URL for accessing files, empty = use proxy
 
+    # Agent BE
+    agent_base_url: str = "http://agent-be:8000"
+    agent_api_key: str = ""
+    agent_timeout: float = 60.0
+
     # CORS
     cors_origins: List[str] = ["*"]
     cors_allow_credentials: bool = True

--- a/backend/app/infrastructure/web/api/deps.py
+++ b/backend/app/infrastructure/web/api/deps.py
@@ -2,6 +2,7 @@
 from fastapi import Depends, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.application.services.agent_proxy_service import AgentProxyService
 from app.application.services.jwt_service import JWTService
 from app.infrastructure.database.config import DatabaseConfig
 from app.infrastructure.database.repositories.user_repository_impl import SQLUserRepository
@@ -115,6 +116,10 @@ def get_password_hasher() -> PasswordHasher:
 
 def get_jwt_service() -> JWTService:
     return JWTService()
+
+
+def get_agent_proxy_service(request: Request) -> AgentProxyService:
+    return request.app.state.agent_proxy_service
 
 
 async def get_current_user(

--- a/backend/app/infrastructure/web/api/v1/endpoints/chat.py
+++ b/backend/app/infrastructure/web/api/v1/endpoints/chat.py
@@ -1,8 +1,11 @@
 """Chat endpoints."""
-from typing import List
+import json
+import logging
+from typing import AsyncGenerator, List
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
 
 from app.application.dto.chat_dto import (
     CreateSessionDTO,
@@ -11,12 +14,16 @@ from app.application.dto.chat_dto import (
     SendMessageDTO,
     SessionResponseDTO,
 )
+from app.application.services.agent_proxy_service import AgentProxyService
 from app.application.services.chat_session_service import ChatSessionService
+from app.domain.entities.chat_message import ChatMessage
 from app.domain.value_objects.chat_role import ChatRole
 from app.infrastructure.database.repositories.chat_session_repository_impl import SQLChatSessionRepository
 from app.infrastructure.database.repositories.chat_message_repository_impl import SQLChatMessageRepository
 from app.infrastructure.security.jwt import get_current_active_user, UserResponseDTO
 from app.infrastructure.web.api import deps
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 service = ChatSessionService()
@@ -74,25 +81,95 @@ async def get_messages(
     return await service.get_messages(session_repo, message_repo, session_id, current_user.id)
 
 
-@router.post("/sessions/{session_id}/message", response_model=MessageResponseDTO)
+@router.post("/sessions/{session_id}/message")
 async def send_message(
     session_id: UUID,
     data: SendMessageDTO,
+    request: Request,
     current_user: UserResponseDTO = Depends(get_current_active_user),
     session_repo: SQLChatSessionRepository = Depends(deps.get_chat_session_repo),
     message_repo: SQLChatMessageRepository = Depends(deps.get_chat_message_repo),
+    agent_proxy: AgentProxyService = Depends(deps.get_agent_proxy_service),
 ):
-    """Send a message to a session. Skeleton for now — SSE streaming in Phase C."""
-    # Verify session exists and belongs to user
+    """Send a message and stream the AI response via SSE."""
+    # 1. Verify session ownership
     session = await session_repo.get_by_id(session_id)
     if not session:
-        from fastapi import HTTPException
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
     if not session.is_owned_by(current_user.id):
-        from fastapi import HTTPException
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not your session")
 
-    # Save user message to DB
-    return await service.save_message(
+    # 2. Save user message (always, even if agent fails)
+    await service.save_message(
         message_repo, session_id, ChatRole.USER, data.content
+    )
+
+    # 3. Load full conversation history
+    messages = await message_repo.list_by_session(session_id)
+    agent_messages = [{"role": m.role.value, "content": m.content} for m in messages]
+
+    # 4. SSE generator — proxies Agent BE stream, saves assistant msg after done
+    async def sse_generator() -> AsyncGenerator[str, None]:
+        collected_parts: list[str] = []
+        collected_sources = None
+        db_config = request.app.state.db_config
+
+        try:
+            async for line in agent_proxy.stream_chat(
+                messages=agent_messages,
+                thread_id=str(session_id),
+                user_metadata={"user_id": str(current_user.id)},
+            ):
+                if await request.is_disconnected():
+                    logger.info("Client disconnected during stream for session %s", session_id)
+                    break
+
+                # Forward line immediately
+                yield line
+
+                # Parse for bookkeeping
+                if line.startswith("data: "):
+                    try:
+                        payload = json.loads(line[6:])
+                        event_type = payload.get("type")
+
+                        if event_type == "token":
+                            content = payload.get("content", "")
+                            if content:
+                                collected_parts.append(content)
+                        elif event_type == "sources":
+                            collected_sources = payload.get("files")
+                        elif event_type == "done":
+                            full_content = "".join(collected_parts)
+                            if full_content:
+                                try:
+                                    async with db_config.session_maker() as db_session:
+                                        msg_repo = SQLChatMessageRepository(db_session)
+                                        msg = ChatMessage(
+                                            session_id=session_id,
+                                            role=ChatRole.ASSISTANT,
+                                            content=full_content,
+                                            sources={"files": collected_sources} if collected_sources else None,
+                                        )
+                                        await msg_repo.save(msg)
+                                except Exception as exc:
+                                    logger.error(
+                                        "Failed to save assistant message for session %s: %s",
+                                        session_id, exc,
+                                    )
+                    except (json.JSONDecodeError, TypeError):
+                        pass  # malformed data line — skip
+
+        except Exception as exc:
+            logger.error("Unexpected error in SSE generator: %s", exc)
+            yield f"data: {json.dumps({'type': 'error', 'content': 'Internal streaming error'})}\n\n"
+
+    return StreamingResponse(
+        sse_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,6 +37,10 @@ async def lifespan(app: FastAPI):
     # Setup JWT service for authentication
     from app.application.services.jwt_service import JWTService
     app.state.jwt_service = JWTService()
+
+    # Setup Agent proxy service
+    from app.application.services.agent_proxy_service import AgentProxyService
+    app.state.agent_proxy_service = AgentProxyService()
     
     # Create tables (for development - use Alembic in production)
     if settings.env == "development":
@@ -46,6 +50,7 @@ async def lifespan(app: FastAPI):
     yield
     
     # Shutdown
+    await app.state.agent_proxy_service.close()
     await db_config.close()
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,12 +26,12 @@ bcrypt = "4.0.1"
 python-multipart = "^0.0.6"
 structlog = "^23.2.0"
 minio = "^7.2.0"
+httpx = "^0.25.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"
 pytest-asyncio = "^0.21.1"
 pytest-cov = "^4.1.0"
-httpx = "^0.25.2"
 black = "^23.11.0"
 isort = "^5.12.0"
 flake8 = "^6.1.0"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,22 +13,6 @@ server {
     # Allow large request bodies (base64 images in rich text)
     client_max_body_size 20M;
 
-    # SSE streaming endpoint — no buffering, long timeout
-    location ^~ /api/v1/chat/sessions/ {
-        proxy_pass http://innovation_hub_api:8000/api/v1/chat/sessions/;
-        proxy_http_version 1.1;
-        proxy_set_header Connection '';
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_buffering off;
-        proxy_cache off;
-        proxy_read_timeout 3600s;
-        proxy_send_timeout 60s;
-        chunked_transfer_encoding on;
-    }
-
     # API proxy to backend - ^~ ensures priority over regex locations (e.g. static assets)
     location ^~ /api/ {
         # Use backend container name or Docker service name
@@ -42,9 +26,11 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
 
+        # SSE support: X-Accel-Buffering: no from backend disables buffering per-response
+        proxy_buffering off;
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_read_timeout 3600s;
     }
 
     # Handle React Router

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,6 +13,22 @@ server {
     # Allow large request bodies (base64 images in rich text)
     client_max_body_size 20M;
 
+    # SSE streaming endpoint — no buffering, long timeout
+    location ^~ /api/v1/chat/sessions/ {
+        proxy_pass http://innovation_hub_api:8000/api/v1/chat/sessions/;
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 60s;
+        chunked_transfer_encoding on;
+    }
+
     # API proxy to backend - ^~ ensures priority over regex locations (e.g. static assets)
     location ^~ /api/ {
         # Use backend container name or Docker service name
@@ -25,8 +41,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
-        
-        # Increase timeout for long requests
+
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;


### PR DESCRIPTION
## Summary
- Add SSE proxy layer that forwards chat messages to Agent BE via streaming
- `AgentProxyService` with `httpx.AsyncClient` for connection pooling and error handling
- Rewrite `send_message()` as SSE endpoint: save user msg → proxy to Agent → save assistant msg
- Nginx config with dedicated SSE location (`proxy_buffering off`, 3600s timeout)
- Move `httpx` from dev to main dependencies

## Test plan
- [ ] Start backend + Agent BE (or mock), send message via SSE → verify tokens stream in real-time
- [ ] GET messages endpoint → verify both user + assistant messages persisted
- [ ] Stop Agent BE → send message → verify user msg saved + error event received
- [ ] Test through nginx (port 3000) → verify no buffering

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)