### PR TITLE
Feat: Per-user LLM API Key for AI Chatbot (#97)

### DIFF
--- a/backend/app/application/dto/user_dto.py
+++ b/backend/app/application/dto/user_dto.py
@@ -65,6 +65,7 @@ class UserResponseDTO(BaseModel):
     role: UserRole
     team: Optional[str] = None
     avatar_url: Optional[str] = None
+    llm_api_key_set: bool = False
     is_active: bool
     created_at: datetime
     updated_at: Optional[datetime] = None

--- a/backend/app/application/services/agent_proxy_service.py
+++ b/backend/app/application/services/agent_proxy_service.py
@@ -39,6 +39,7 @@ class AgentProxyService:
         messages: List[Dict[str, str]],
         thread_id: Optional[str] = None,
         user_metadata: Optional[Dict[str, Any]] = None,
+        llm_api_key: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
         """Stream SSE events from Agent BE.
 
@@ -49,6 +50,7 @@ class AgentProxyService:
         url = f"{self._base_url}/api/chat/stream"
         headers = {
             "X-API-Key": self._api_key,
+            "X-LLM-API-Key": llm_api_key or "",
             "Content-Type": "application/json",
             "Accept": "text/event-stream",
         }
@@ -81,6 +83,46 @@ class AgentProxyService:
             logger.error("Agent BE timed out: %s", exc)
             yield _sse_error("Agent service timed out. Please try again.")
 
+    async def validate_key(self, llm_api_key: str, timeout: int = 20) -> Dict[str, Any]:
+        """Validate an LLM API key via Agent BE's /api/validate-key endpoint."""
+        url = f"{self._base_url}/api/validate-key"
+        headers = {
+            "X-API-Key": self._api_key,
+            "X-LLM-API-Key": llm_api_key,
+            "Content-Type": "application/json",
+        }
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(connect=5.0, read=float(timeout), write=5.0, pool=5.0)) as client:
+                resp = await client.post(url, headers=headers)
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.ConnectError as exc:
+            logger.error("Cannot connect to Agent BE for key validation: %s", exc)
+            return {"valid": False, "reason": "agent_unreachable"}
+        except httpx.ReadTimeout:
+            logger.warning("Key validation timed out (timeout=%ds)", timeout)
+            raise  # Let caller retry
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            logger.error("Key validation returned %s", status)
+            if status == 401:
+                return {"valid": False, "reason": "agent_auth_failed"}
+            return {"valid": False, "reason": "error", "detail": f"Agent BE returned HTTP {status}"}
+        except Exception as exc:
+            logger.error("Key validation failed: %s", exc)
+            return {"valid": False, "reason": "error", "detail": str(exc)[:200]}
+
 
 def _sse_error(message: str) -> str:
     return f"data: {json.dumps({'type': 'error', 'content': message})}\n\n"
+
+
+# Module-level singleton for reuse across requests
+_proxy: Optional[AgentProxyService] = None
+
+
+def get_proxy() -> AgentProxyService:
+    global _proxy
+    if _proxy is None:
+        _proxy = AgentProxyService()
+    return _proxy

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -47,6 +47,7 @@ class Settings(BaseSettings):
     agent_base_url: str = "http://agent-be:8000"
     agent_api_key: str = ""
     agent_timeout: float = 60.0
+    agent_key_help_url: str = "https://wiki.internal/how-to-get-api-key"
 
     # CORS
     cors_origins: List[str] = ["*"]

--- a/backend/app/domain/entities/user.py
+++ b/backend/app/domain/entities/user.py
@@ -19,6 +19,7 @@ class User:
     role: UserRole = field(default=UserRole.MEMBER)
     team: Optional[str] = None
     avatar_url: Optional[str] = None
+    llm_api_key: Optional[str] = None
     is_active: bool = field(default=True)
     created_at: datetime = field(default_factory=datetime.utcnow)
     updated_at: Optional[datetime] = None
@@ -54,6 +55,11 @@ class User:
     def is_admin(self) -> bool:
         """Check if user has admin role."""
         return self.role == UserRole.ADMIN
+
+    @property
+    def llm_api_key_set(self) -> bool:
+        """Whether the user has configured an LLM API key."""
+        return bool(self.llm_api_key)
     
     def set_role(self, role: UserRole) -> None:
         """Set user role."""

--- a/backend/app/infrastructure/database/migrations/versions/2026_05_05_001000_add_llm_api_key_to_users.py
+++ b/backend/app/infrastructure/database/migrations/versions/2026_05_05_001000_add_llm_api_key_to_users.py
@@ -1,0 +1,23 @@
+"""Add llm_api_key column to users table
+
+Revision ID: add_llm_api_key
+Revises: add_chat_tables
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "add_llm_api_key"
+down_revision = "add_chat_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("llm_api_key", sa.String(255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "llm_api_key")

--- a/backend/app/infrastructure/database/models/user_model.py
+++ b/backend/app/infrastructure/database/models/user_model.py
@@ -30,6 +30,7 @@ class UserModel(BaseModel):
     role: Mapped[str] = mapped_column(String(20), default=UserRole.MEMBER.value)
     team: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     avatar_url: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    llm_api_key: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     
     # Relationships

--- a/backend/app/infrastructure/database/repositories/user_repository_impl.py
+++ b/backend/app/infrastructure/database/repositories/user_repository_impl.py
@@ -30,6 +30,7 @@ class SQLUserRepository(UserRepository):
             role=UserRole(model.role),
             team=model.team,
             avatar_url=model.avatar_url,
+            llm_api_key=model.llm_api_key,
             is_active=model.is_active,
             created_at=model.created_at,
             updated_at=model.updated_at
@@ -46,6 +47,7 @@ class SQLUserRepository(UserRepository):
             role=entity.role.value,
             team=entity.team,
             avatar_url=entity.avatar_url,
+            llm_api_key=entity.llm_api_key,
             is_active=entity.is_active,
             created_at=entity.created_at,
             updated_at=entity.updated_at
@@ -138,6 +140,7 @@ class SQLUserRepository(UserRepository):
         model.role = user.role.value
         model.team = user.team
         model.avatar_url = user.avatar_url
+        model.llm_api_key = user.llm_api_key
         model.is_active = user.is_active
         model.updated_at = user.updated_at
         

--- a/backend/app/infrastructure/web/api/v1/endpoints/chat.py
+++ b/backend/app/infrastructure/web/api/v1/endpoints/chat.py
@@ -1,6 +1,7 @@
 """Chat endpoints."""
 import json
 import logging
+from enum import Enum
 from typing import AsyncGenerator, List
 from uuid import UUID
 
@@ -29,6 +30,10 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 service = ChatSessionService()
+
+
+class ChatErrorCode(str, Enum):
+    NO_API_KEY = "NO_API_KEY"
 
 
 @router.post("/sessions", response_model=SessionResponseDTO, status_code=status.HTTP_201_CREATED)
@@ -99,7 +104,7 @@ async def send_message(
     user = await user_repo.get_by_id(current_user.id)
     if not user or not user.llm_api_key:
         return StreamingResponse(
-            iter([f"data: {json.dumps({'type': 'error', 'content': 'NO_API_KEY'})}\n\n"]),
+            iter([f"data: {json.dumps({'type': 'error', 'content': ChatErrorCode.NO_API_KEY})}\n\n"]),
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
         )

--- a/backend/app/infrastructure/web/api/v1/endpoints/chat.py
+++ b/backend/app/infrastructure/web/api/v1/endpoints/chat.py
@@ -16,10 +16,12 @@ from app.application.dto.chat_dto import (
 )
 from app.application.services.agent_proxy_service import AgentProxyService
 from app.application.services.chat_session_service import ChatSessionService
+from app.core.config import get_settings
 from app.domain.entities.chat_message import ChatMessage
 from app.domain.value_objects.chat_role import ChatRole
 from app.infrastructure.database.repositories.chat_session_repository_impl import SQLChatSessionRepository
 from app.infrastructure.database.repositories.chat_message_repository_impl import SQLChatMessageRepository
+from app.infrastructure.database.repositories.user_repository_impl import SQLUserRepository
 from app.infrastructure.security.jwt import get_current_active_user, UserResponseDTO
 from app.infrastructure.web.api import deps
 
@@ -90,8 +92,18 @@ async def send_message(
     session_repo: SQLChatSessionRepository = Depends(deps.get_chat_session_repo),
     message_repo: SQLChatMessageRepository = Depends(deps.get_chat_message_repo),
     agent_proxy: AgentProxyService = Depends(deps.get_agent_proxy_service),
+    user_repo: SQLUserRepository = Depends(deps.get_user_repo),
 ):
     """Send a message and stream the AI response via SSE."""
+    # 0. Load user's LLM API key
+    user = await user_repo.get_by_id(current_user.id)
+    if not user or not user.llm_api_key:
+        return StreamingResponse(
+            iter([f"data: {json.dumps({'type': 'error', 'content': 'NO_API_KEY'})}\n\n"]),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+        )
+
     # 1. Verify session ownership
     session = await session_repo.get_by_id(session_id)
     if not session:
@@ -127,6 +139,7 @@ async def send_message(
                     "username": current_user.username,
                     "role": current_user.role.value,
                 },
+                llm_api_key=user.llm_api_key,
             ):
                 if await request.is_disconnected():
                     logger.info("Client disconnected during stream for session %s", session_id)
@@ -183,3 +196,10 @@ async def send_message(
             "X-Accel-Buffering": "no",
         },
     )
+
+
+@router.get("/key-help-url")
+async def get_key_help_url():
+    """Return the help URL for getting an LLM API key. No auth required."""
+    settings = get_settings()
+    return {"url": settings.agent_key_help_url}

--- a/backend/app/infrastructure/web/api/v1/endpoints/users.py
+++ b/backend/app/infrastructure/web/api/v1/endpoints/users.py
@@ -1,9 +1,12 @@
 """User endpoints."""
+import logging
 import secrets
 import string
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -23,6 +26,9 @@ from app.infrastructure.database.repositories.user_repository_impl import SQLUse
 from app.infrastructure.security.jwt import get_current_active_user, require_admin, UserResponseDTO as AuthUser
 from app.infrastructure.security.password import PasswordHasher
 from app.infrastructure.web.api import deps
+from app.application.services.agent_proxy_service import AgentProxyService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -211,3 +217,81 @@ async def admin_reset_password(
 
     await user_repo.update(user)
     return {"new_password": new_password}
+
+
+# ── LLM API Key management ──────────────────────────────────────────────────
+
+class LlmApiKeyInput(BaseModel):
+    llm_api_key: str
+
+
+@router.put("/me/llm-api-key")
+async def save_llm_api_key(
+    data: LlmApiKeyInput,
+    current_user: AuthUser = Depends(get_current_active_user),
+    user_repo: SQLUserRepository = Depends(deps.get_user_repo),
+    agent_proxy: AgentProxyService = Depends(deps.get_agent_proxy_service),
+):
+    """Save and validate the current user's LLM API key."""
+    user = await user_repo.get_by_id(current_user.id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user.llm_api_key = data.llm_api_key
+    user.updated_at = datetime.utcnow()
+    await user_repo.update(user)
+
+    # Validate with 30s timeout
+    try:
+        result = await agent_proxy.validate_key(data.llm_api_key, timeout=30)
+    except Exception as e:
+        logger.warning("Key validation timed out or failed: %s", e)
+        return {"saved": True, "valid": False, "reason": "timeout"}
+
+    if result.get("valid"):
+        return {"saved": True, "valid": True}
+
+    return {"saved": True, "valid": False, "reason": result.get("reason", "error"), "detail": result.get("detail")}
+
+
+@router.delete("/me/llm-api-key", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_llm_api_key(
+    current_user: AuthUser = Depends(get_current_active_user),
+    user_repo: SQLUserRepository = Depends(deps.get_user_repo),
+):
+    """Delete the current user's LLM API key."""
+    user = await user_repo.get_by_id(current_user.id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user.llm_api_key = None
+    user.updated_at = datetime.utcnow()
+    await user_repo.update(user)
+
+
+@router.get("/me/llm-api-key")
+async def check_llm_api_key(
+    current_user: AuthUser = Depends(get_current_active_user),
+    user_repo: SQLUserRepository = Depends(deps.get_user_repo),
+):
+    """Check if the current user has an LLM API key configured."""
+    user = await user_repo.get_by_id(current_user.id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"has_key": bool(user.llm_api_key)}
+
+
+@router.post("/me/validate-llm-key")
+async def validate_llm_api_key(
+    current_user: AuthUser = Depends(get_current_active_user),
+    user_repo: SQLUserRepository = Depends(deps.get_user_repo),
+    agent_proxy: AgentProxyService = Depends(deps.get_agent_proxy_service),
+):
+    """Validate the current user's LLM API key via Agent BE."""
+    user = await user_repo.get_by_id(current_user.id)
+    if not user or not user.llm_api_key:
+        return {"valid": False, "error": "No API key configured"}
+    try:
+        result = await agent_proxy.validate_key(user.llm_api_key)
+        return result
+    except Exception as e:
+        logger.error("Key validation failed: %s", e)
+        return {"valid": False, "error": str(e)}

--- a/backend/app/infrastructure/web/api/v1/endpoints/users.py
+++ b/backend/app/infrastructure/web/api/v1/endpoints/users.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -222,7 +222,7 @@ async def admin_reset_password(
 # ── LLM API Key management ──────────────────────────────────────────────────
 
 class LlmApiKeyInput(BaseModel):
-    llm_api_key: str
+    llm_api_key: str = Field(min_length=8, max_length=255)
 
 
 @router.put("/me/llm-api-key")

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -53,4 +53,21 @@ export const usersApi = {
     const response = await apiClient.post<{ new_password: string }>(`/users/${userId}/reset-password`);
     return response.data;
   },
+
+  // LLM API Key
+  saveLlmApiKey: async (key: string): Promise<{ saved: boolean; valid?: boolean; reason?: string; detail?: string }> => {
+    const { data } = await apiClient.put('/users/me/llm-api-key', { llm_api_key: key });
+    return data;
+  },
+  deleteLlmApiKey: async (): Promise<void> => {
+    await apiClient.delete('/users/me/llm-api-key');
+  },
+  checkLlmApiKey: async (): Promise<{ has_key: boolean }> => {
+    const { data } = await apiClient.get('/users/me/llm-api-key');
+    return data;
+  },
+  getKeyHelpUrl: async (): Promise<{ url: string }> => {
+    const { data } = await apiClient.get('/chat/key-help-url');
+    return data;
+  },
 };

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1,7 +1,9 @@
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
-import { X, MessageSquarePlus, PanelLeftClose, PanelLeft, Maximize2, Minimize2 } from 'lucide-react';
+import { X, MessageSquarePlus, PanelLeftClose, PanelLeft, Maximize2, Minimize2, KeyRound, ExternalLink, Bot } from 'lucide-react';
 import { useChatStore } from '@/stores/chatStore';
+import { usersApi } from '@/api/users';
 import { ChatSidebar } from './ChatSidebar';
 import { ChatMessageList } from './ChatMessageList';
 import { ChatMessageInput } from './ChatMessageInput';
@@ -27,6 +29,40 @@ const fullscreenVariants = {
   exit: { opacity: 0, transition: { duration: 0.15 } },
 };
 
+/** Full-area view when user hasn't configured their API key yet. */
+const NoApiKeyView: React.FC<{ helpUrl: string }> = ({ helpUrl }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center px-6 text-center">
+      <div className="w-16 h-16 rounded-full bg-amber-100 flex items-center justify-center mb-4">
+        <KeyRound className="w-8 h-8 text-amber-500" />
+      </div>
+      <h3 className="text-lg font-semibold text-foreground mb-1">{t('chat.no_key_heading')}</h3>
+      <p className="text-sm text-muted-foreground mb-4 max-w-[260px]">
+        {t('chat.no_key_desc')}
+      </p>
+      <div className="flex flex-col gap-2 w-full max-w-[240px]">
+        <a
+          href="/settings"
+          className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-primary text-white text-sm font-medium hover:bg-primary-700 transition-colors"
+        >
+          {t('chat.no_key_setup')}
+        </a>
+        {helpUrl && (
+          <a
+            href={helpUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center gap-1.5 px-4 py-2 text-sm text-primary-600 hover:underline"
+          >
+            {t('chat.no_key_guide')} <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+};
+
 export const ChatPanel: React.FC = () => {
   const { t } = useTranslation();
   const closePanel = useChatStore((s) => s.closePanel);
@@ -36,23 +72,83 @@ export const ChatPanel: React.FC = () => {
   const toggleFullscreen = useChatStore((s) => s.toggleFullscreen);
   const startNewChat = useChatStore((s) => s.startNewChat);
   const currentSessionId = useChatStore((s) => s.currentSessionId);
+  const [hasApiKey, setHasApiKey] = useState<boolean | null>(null);
+  const [helpUrl, setHelpUrl] = useState('');
+
+  useEffect(() => {
+    usersApi.checkLlmApiKey().then(r => setHasApiKey(r.has_key)).catch(() => setHasApiKey(false));
+    usersApi.getKeyHelpUrl().then(r => setHelpUrl(r.url)).catch(() => {});
+  }, []);
+
+  const needsKey = hasApiKey === false;
+  const loading = hasApiKey === null;
+  const panelTitle = needsKey ? t('chat.no_key_title') : (currentSessionId ? t('chat.title') : t('chat.new_chat'));
+
+  // Don't render until API key check completes — avoids flash of wrong view
+  if (loading) return null;
 
   const handleNewChat = () => {
     startNewChat();
   };
+
+  // ── No API Key: full-panel view, no sidebar ──
+  if (needsKey) {
+    return (
+      <>
+        {/* Mobile */}
+        <motion.div
+          className="fixed inset-0 z-50 bg-card flex flex-col md:hidden"
+          variants={mobileVariants} initial="hidden" animate="visible" exit="exit"
+        >
+          <SimpleHeader title={panelTitle} onClose={closePanel} />
+          <NoApiKeyView helpUrl={helpUrl} />
+        </motion.div>
+
+        {/* Desktop normal panel */}
+        {!isFullscreen && (
+          <motion.div
+            className="hidden md:flex fixed bottom-24 right-6 z-50 h-[600px] w-[400px]
+              bg-card border border-border rounded-feature shadow-clay-lg
+              flex-col overflow-hidden"
+            variants={panelVariants} initial="hidden" animate={panelVariants.visible} exit="exit"
+            transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+          >
+            <SimpleHeader title={panelTitle} onClose={closePanel} onToggleFullscreen={toggleFullscreen} />
+            <NoApiKeyView helpUrl={helpUrl} />
+          </motion.div>
+        )}
+
+        {/* Desktop fullscreen */}
+        {isFullscreen && (
+          <motion.div
+            className="hidden md:flex fixed top-16 left-0 right-0 bottom-0 z-50 bg-card border-t border-border flex-col"
+            variants={fullscreenVariants} initial="hidden" animate="visible" exit="exit"
+          >
+            <SimpleHeader title={panelTitle} onClose={closePanel} onToggleFullscreen={toggleFullscreen} />
+            <NoApiKeyView helpUrl={helpUrl} />
+          </motion.div>
+        )}
+      </>
+    );
+  }
+
+  // ── Normal chat view ──
+  const chatContent = (
+    <>
+      <ChatMessageList />
+      <ChatMessageInput />
+    </>
+  );
 
   return (
     <>
       {/* Mobile: full-screen overlay */}
       <motion.div
         className="fixed inset-0 z-50 bg-card flex flex-col md:hidden"
-        variants={mobileVariants}
-        initial="hidden"
-        animate="visible"
-        exit="exit"
+        variants={mobileVariants} initial="hidden" animate="visible" exit="exit"
       >
         <ChatPanelHeader
-          title={currentSessionId ? t('chat.title') : t('chat.new_chat')}
+          title={panelTitle}
           onClose={closePanel}
           onToggleSidebar={() => setShowSidebar(!showSidebar)}
           onNewChat={handleNewChat}
@@ -65,24 +161,20 @@ export const ChatPanel: React.FC = () => {
             </div>
           ) : (
             <div className="flex-1 flex flex-col overflow-hidden">
-              <ChatMessageList />
-              <ChatMessageInput />
+              {chatContent}
             </div>
           )}
         </div>
       </motion.div>
 
-      {/* Desktop: fullscreen — below header, sidebar overlaps Hub sidebar */}
+      {/* Desktop: fullscreen */}
       {isFullscreen && (
         <motion.div
           className="hidden md:flex fixed top-16 left-0 right-0 bottom-0 z-50 bg-card border-t border-border flex-col"
-          variants={fullscreenVariants}
-          initial="hidden"
-          animate="visible"
-          exit="exit"
+          variants={fullscreenVariants} initial="hidden" animate="visible" exit="exit"
         >
           <ChatPanelHeader
-            title={currentSessionId ? t('chat.title') : t('chat.new_chat')}
+            title={panelTitle}
             onClose={closePanel}
             onToggleSidebar={() => setShowSidebar(!showSidebar)}
             onNewChat={handleNewChat}
@@ -101,8 +193,7 @@ export const ChatPanel: React.FC = () => {
               </div>
             </motion.div>
             <div className="flex-1 flex flex-col overflow-hidden">
-              <ChatMessageList />
-              <ChatMessageInput />
+              {chatContent}
             </div>
           </div>
         </motion.div>
@@ -124,7 +215,7 @@ export const ChatPanel: React.FC = () => {
           transition={{ type: 'spring', damping: 25, stiffness: 300 }}
         >
           <ChatPanelHeader
-            title={currentSessionId ? t('chat.title') : t('chat.new_chat')}
+            title={panelTitle}
             onClose={closePanel}
             onToggleSidebar={() => setShowSidebar(!showSidebar)}
             onNewChat={handleNewChat}
@@ -143,8 +234,7 @@ export const ChatPanel: React.FC = () => {
               </div>
             </motion.div>
             <div style={{ width: CHAT_WIDTH, flexShrink: 0 }} className="flex flex-col overflow-hidden">
-              <ChatMessageList />
-              <ChatMessageInput />
+              {chatContent}
             </div>
           </div>
         </motion.div>
@@ -193,6 +283,36 @@ const ChatPanelHeader: React.FC<HeaderProps> = ({
       >
         {isFullscreen ? <Minimize2 className="w-4 h-4" /> : <Maximize2 className="w-4 h-4" />}
       </button>
+      <button
+        onClick={onClose}
+        className="p-1.5 rounded-standard text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  </div>
+);
+
+/** Minimal header for no-key view — no sidebar toggle, no new chat. */
+const SimpleHeader: React.FC<{ title: string; onClose: () => void; onToggleFullscreen?: () => void }> = ({
+  title, onClose, onToggleFullscreen,
+}) => (
+  <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-card flex-shrink-0">
+    <div className="flex items-center gap-2">
+      <div className="p-1.5">
+        <Bot className="w-4 h-4 text-primary" />
+      </div>
+      <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+    </div>
+    <div className="flex items-center gap-1">
+      {onToggleFullscreen && (
+        <button
+          onClick={onToggleFullscreen}
+          className="p-1.5 rounded-standard text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+        >
+          <Maximize2 className="w-4 h-4" />
+        </button>
+      )}
       <button
         onClick={onClose}
         className="p-1.5 rounded-standard text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,7 +1,24 @@
 import { useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useChatStore } from '@/stores/chatStore';
 import { chatApi } from '@/api/chat';
 import type { ChatMessage, StreamEvent, StreamingStep } from '@/types/chat';
+
+const ERROR_KEY_MAP: Record<string, string> = {
+  NO_API_KEY: 'chat.error_no_api_key',
+  AUTH_FAILED: 'chat.error_auth_failed',
+  RATE_LIMITED: 'chat.error_rate_limited',
+  TIMEOUT: 'chat.error_timeout',
+  CONNECTION_ERROR: 'chat.error_connection',
+  STREAM_ERROR: 'chat.error_stream',
+};
+
+function mapSSEError(content: string): string {
+  if (ERROR_KEY_MAP[content]) return ERROR_KEY_MAP[content];
+  // If it's a raw error code we don't recognize, return generic
+  if (content.length < 30 && /^[A-Z_]+$/.test(content)) return 'chat.error_stream';
+  return content;
+}
 
 function parseSSELine(line: string): StreamEvent | null {
   if (!line.startsWith('data: ')) return null;
@@ -13,6 +30,7 @@ function parseSSELine(line: string): StreamEvent | null {
 }
 
 export function useChat() {
+  const { t } = useTranslation();
   const abortRef = useRef<AbortController | null>(null);
 
   const sendMessage = useCallback(async (content: string) => {
@@ -140,7 +158,8 @@ export function useChat() {
             }
             case 'error':
               if (active) {
-                useChatStore.getState().setError(event.content || 'Streaming error');
+                const errorKey = mapSSEError(event.content || '');
+                useChatStore.getState().setError(t(errorKey));
                 useChatStore.getState().setStreaming(false);
               }
               useChatStore.getState().setStreamingSessionId(null);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -415,7 +415,25 @@
     "password_changed": "Password changed!",
     "password_error": "Failed to change password. Check your current password.",
     "language": "Language",
-    "language_desc": "Choose your preferred language"
+    "language_desc": "Choose your preferred language",
+    "api_key_tab": "API Key",
+    "api_key_title": "AI Chat API Key",
+    "api_key_desc": "API Key used to call the AI model. Each user needs to configure their own key.",
+    "api_key_guide": "How to get a key",
+    "api_key_saved": "API Key saved",
+    "api_key_save_fail": "Failed to save",
+    "api_key_deleted": "API Key deleted",
+    "api_key_delete_fail": "Failed to delete",
+    "api_key_valid": "API Key is valid. Saved successfully!",
+    "api_key_invalid": "API Key is invalid. Please check and try again.",
+    "api_key_agent_unreachable": "Cannot connect to AI Agent. Key saved but not verified.",
+    "api_key_llm_unreachable": "Cannot connect to LLM service. Key saved but not verified.",
+    "api_key_validate_error": "Could not verify key. Key has been saved.",
+    "api_key_timeout": "Key verification timed out. Key saved — will verify when you chat.",
+    "api_key_validating": "Validating...",
+    "api_key_placeholder_saved": "•••••••••••••••• (saved, enter new to replace)",
+    "api_key_save": "Save Key",
+    "api_key_delete": "Delete"
   },
   "admin": {
     "users_title": "User Management",
@@ -946,6 +964,17 @@
     "session_default_title": "New Chat",
     "suggest_innovation": "What is Innovation Hub about?",
     "suggest_problem": "How do I submit a problem?",
-    "suggest_idea": "How does the idea voting system work?"
+    "suggest_idea": "How does the idea voting system work?",
+    "no_key_title": "API Key Required",
+    "no_key_heading": "API Key Not Configured",
+    "no_key_desc": "You need to add an API Key to use AI Chat.",
+    "no_key_setup": "Set Up Now",
+    "no_key_guide": "How to get an API Key",
+    "error_no_api_key": "API Key not configured. Please add it in Settings.",
+    "error_auth_failed": "API Key is invalid or expired. Please check it in Settings.",
+    "error_rate_limited": "API rate limit exceeded. Please try again later.",
+    "error_timeout": "Request timed out. Please try again.",
+    "error_connection": "Cannot connect to AI service. Please try again later.",
+    "error_stream": "An error occurred. Please try again."
   }
 }

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -409,7 +409,25 @@
     "password_changed": "Đã đổi mật khẩu!",
     "password_error": "Không thể đổi mật khẩu. Kiểm tra lại mật khẩu hiện tại.",
     "language": "Ngôn ngữ",
-    "language_desc": "Chọn ngôn ngữ hiển thị"
+    "language_desc": "Chọn ngôn ngữ hiển thị",
+    "api_key_tab": "API Key",
+    "api_key_title": "AI Chat API Key",
+    "api_key_desc": "API Key dùng để gọi mô hình AI. Mỗi người dùng cần tự cấu hình key riêng.",
+    "api_key_guide": "Hướng dẫn lấy key",
+    "api_key_saved": "Đã lưu API Key",
+    "api_key_save_fail": "Lưu thất bại",
+    "api_key_deleted": "Đã xóa API Key",
+    "api_key_delete_fail": "Xóa thất bại",
+    "api_key_valid": "API Key hợp lệ. Đã lưu thành công!",
+    "api_key_invalid": "API Key không hợp lệ. Vui lòng kiểm tra lại.",
+    "api_key_agent_unreachable": "Không kết nối được đến AI Agent. Key đã được lưu nhưng chưa xác minh được.",
+    "api_key_llm_unreachable": "Không kết nối được đến dịch vụ LLM. Key đã được lưu nhưng chưa xác minh được.",
+    "api_key_validate_error": "Không thể xác minh key. Key đã được lưu.",
+    "api_key_timeout": "Xác minh key quá thời gian. Key đã được lưu, sẽ kiểm tra lại khi bạn chat.",
+    "api_key_validating": "Đang kiểm tra...",
+    "api_key_placeholder_saved": "•••••••••••••••• (đã lưu, nhập mới để thay thế)",
+    "api_key_save": "Lưu Key",
+    "api_key_delete": "Xóa"
   },
   "admin": {
     "users_title": "Quản lý Người dùng",
@@ -940,6 +958,17 @@
     "session_default_title": "Cuộc trò chuyện mới",
     "suggest_innovation": "Innovation Hub là gì?",
     "suggest_problem": "Làm sao để submit một vấn đề?",
-    "suggest_idea": "Hệ thống bình chọn ý tưởng hoạt động như thế nào?"
+    "suggest_idea": "Hệ thống bình chọn ý tưởng hoạt động như thế nào?",
+    "no_key_title": "Yêu cầu cập nhật API Key",
+    "no_key_heading": "Chưa cấu hình API Key",
+    "no_key_desc": "Bạn cần thêm API Key để sử dụng AI Chat.",
+    "no_key_setup": "Cài đặt ngay",
+    "no_key_guide": "Hướng dẫn lấy API Key",
+    "error_no_api_key": "Chưa cấu hình API Key. Vui lòng vào Cài đặt để thêm.",
+    "error_auth_failed": "API Key không hợp lệ hoặc đã hết hạn. Vui lòng kiểm tra lại trong Cài đặt.",
+    "error_rate_limited": "Đã vượt giới hạn gọi API. Vui lòng thử lại sau.",
+    "error_timeout": "Yêu cầu quá thời gian. Vui lòng thử lại.",
+    "error_connection": "Không kết nối được đến dịch vụ AI. Vui lòng thử lại sau.",
+    "error_stream": "Đã xảy ra lỗi. Vui lòng thử lại."
   }
 }

--- a/frontend/src/pages/Settings/UserSettingsPage.tsx
+++ b/frontend/src/pages/Settings/UserSettingsPage.tsx
@@ -1,13 +1,14 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { User, KeyRound, LogOut, Camera } from 'lucide-react';
+import { User, KeyRound, LogOut, Camera, Eye, EyeOff, CheckCircle, XCircle, ExternalLink, Bot } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '@/stores/authStore';
 import { useUIStore } from '@/stores/uiStore';
 import { authApi } from '@/api/auth';
 import { uploadsApi } from '@/api/uploads';
+import { usersApi } from '@/api/users';
 import { Input } from '@/components/ui/Input';
 import { Button } from '@/components/ui/Button';
 import { Card, CardContent, CardHeader } from '@/components/ui/Card';
@@ -38,9 +39,23 @@ export const UserSettingsPage: React.FC = () => {
   const { t, i18n } = useTranslation();
   const { user, updateProfile, logout } = useAuthStore();
   const { showToast } = useUIStore();
-  const [activeTab, setActiveTab] = useState<'profile' | 'password'>('profile');
+  const [activeTab, setActiveTab] = useState<'profile' | 'password' | 'apikey'>('profile');
   const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // API Key state
+  const [apiKey, setApiKey] = useState('');
+  const [showKey, setShowKey] = useState(false);
+  const [hasKey, setHasKey] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [validationResult, setValidationResult] = useState<{ type: 'valid' | 'warning'; message: string } | null>(null);
+  const [helpUrl, setHelpUrl] = useState('');
+  const [saveElapsed, setSaveElapsed] = useState(0);
+
+  useEffect(() => {
+    usersApi.checkLlmApiKey().then(r => setHasKey(r.has_key)).catch(() => {});
+    usersApi.getKeyHelpUrl().then(r => setHelpUrl(r.url)).catch(() => {});
+  }, []);
 
   const {
     register: registerProfile,
@@ -114,6 +129,7 @@ export const UserSettingsPage: React.FC = () => {
   const tabs = [
     { id: 'profile' as const, label: 'settings.profile', icon: User },
     { id: 'password' as const, label: 'settings.password', icon: KeyRound },
+    { id: 'apikey' as const, label: 'settings.api_key_tab', icon: Bot },
   ];
 
   return (
@@ -274,6 +290,116 @@ export const UserSettingsPage: React.FC = () => {
                 </Button>
               </div>
             </form>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* API Key Tab */}
+      {activeTab === 'apikey' && (
+        <Card>
+          <CardHeader>
+            <h3 className="text-feature-title font-semibold text-gray-900">{t('settings.api_key_title')}</h3>
+          </CardHeader>
+          <CardContent className="p-6 pt-4 space-y-4">
+            <p className="text-sm text-gray-500">
+              {t('settings.api_key_desc')}
+              {helpUrl && (
+                <a href={helpUrl} target="_blank" rel="noopener noreferrer" className="ml-1 text-primary-600 hover:underline inline-flex items-center gap-1">
+                  {t('settings.api_key_guide')} <ExternalLink className="h-3 w-3" />
+                </a>
+              )}
+            </p>
+
+            <div className="relative">
+              <input
+                type={showKey ? 'text' : 'password'}
+                value={apiKey}
+                onChange={(e) => { setApiKey(e.target.value); setValidationResult(null); }}
+                placeholder={hasKey ? t('settings.api_key_placeholder_saved') : 'sk-...'}
+                className="w-full rounded-lg border border-gray-300 px-4 py-2.5 pr-10 text-base text-gray-900 focus:border-primary-500 focus:ring-primary-500 focus:outline-none shadow-sm"
+              />
+              <button
+                type="button"
+                onClick={() => setShowKey(!showKey)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+              >
+                {showKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+
+            {validationResult && (
+              <div className={classNames(
+                'flex items-center gap-2 text-sm',
+                validationResult.type === 'valid' ? 'text-green-600' : 'text-amber-600'
+              )}>
+                {validationResult.type === 'valid'
+                  ? <CheckCircle className="h-4 w-4" />
+                  : <XCircle className="h-4 w-4" />
+                }
+                <span>{validationResult.message}</span>
+              </div>
+            )}
+
+            <div className="flex gap-3">
+              <Button
+                onClick={async () => {
+                  if (!apiKey.trim()) return;
+                  setIsSaving(true);
+                  setValidationResult(null);
+                  setIsSaving(true);
+                  setSaveElapsed(0);
+                  const timer = setInterval(() => setSaveElapsed(s => s + 1), 1000);
+                  try {
+                    const result = await usersApi.saveLlmApiKey(apiKey.trim());
+                    setHasKey(true);
+                    if (result.valid) {
+                      setApiKey('');
+                      setValidationResult({ type: 'valid', message: t('settings.api_key_valid') });
+                      showToast({ type: 'success', message: t('settings.api_key_saved') });
+                    } else {
+                      const reasonMsgMap: Record<string, string> = {
+                        invalid_key: t('settings.api_key_invalid'),
+                        agent_unreachable: t('settings.api_key_agent_unreachable'),
+                        llm_unreachable: t('settings.api_key_llm_unreachable'),
+                        timeout: t('settings.api_key_timeout'),
+                        error: t('settings.api_key_validate_error'),
+                      };
+                      const msg = reasonMsgMap[result.reason || 'error'] || t('settings.api_key_invalid');
+                      setApiKey('');
+                      setValidationResult({ type: 'warning', message: msg });
+                      showToast({ type: 'warning', message: msg });
+                    }
+                  } catch {
+                    showToast({ type: 'error', message: t('settings.api_key_save_fail') });
+                  } finally {
+                    clearInterval(timer);
+                    setIsSaving(false);
+                    setSaveElapsed(0);
+                  }
+                }}
+                disabled={!apiKey.trim() || isSaving}
+                isLoading={isSaving}
+              >
+                {isSaving ? `${t('settings.api_key_validating')} ${saveElapsed}s` : t('settings.api_key_save')}
+              </Button>
+              {hasKey && (
+                <Button
+                  variant="danger"
+                  onClick={async () => {
+                    try {
+                      await usersApi.deleteLlmApiKey();
+                      setHasKey(false);
+                      setValidationResult(null);
+                      showToast({ type: 'success', message: t('settings.api_key_deleted') });
+                    } catch {
+                      showToast({ type: 'error', message: t('settings.api_key_delete_fail') });
+                    }
+                  }}
+                >
+                  {t('settings.api_key_delete')}
+                </Button>
+              )}
+            </div>
           </CardContent>
         </Card>
       )}

--- a/frontend/src/pages/Settings/UserSettingsPage.tsx
+++ b/frontend/src/pages/Settings/UserSettingsPage.tsx
@@ -346,7 +346,6 @@ export const UserSettingsPage: React.FC = () => {
                   if (!apiKey.trim()) return;
                   setIsSaving(true);
                   setValidationResult(null);
-                  setIsSaving(true);
                   setSaveElapsed(0);
                   const timer = setInterval(() => setSaveElapsed(s => s + 1), 1000);
                   try {


### PR DESCRIPTION
## Summary

- **Per-user LLM API Key**: Users store their own LLM API key in Settings → Hub BE saves to DB → forwards to Agent BE via `X-LLM-API-Key` header → Agent BE creates LLM client per-request
- **API Key management UI**: New tab in User Settings with save/validate/delete, auto-validation on save with countdown timer
- **Chat no-key view**: Dedicated full-panel view when user hasn't configured API key, with help link and "Cài đặt ngay" button
- **i18n error handling**: Backend returns reason codes (AUTH_FAILED, RATE_LIMITED, etc.), FE maps to i18n keys for both EN/VI
- **SSE streaming improvements**: Error code mapping for stream errors, abort controller fixes
- **Fullscreen mode**: Add fullscreen toggle to chat widget
- **Session management**: Sort sessions by recent activity

## Changes

### Backend
- Add `llm_api_key` column to users table (with Alembic migration)
- `PUT/DELETE/GET /me/llm-api-key` endpoints for key management
- `POST /me/validate-llm-key` for key validation via Agent BE
- `GET /chat/key-help-url` for help link config
- `AgentProxyService` forwards user's LLM key as `X-LLM-API-Key` header
- Chat endpoint loads user key, returns `NO_API_KEY` error if missing

### Frontend
- API Key tab in Settings page (Bot icon, show/hide toggle, auto-validate on save)
- `NoApiKeyView` component for chat when no key configured
- `mapSSEError()` for error code → i18n key translation
- Fullscreen mode for chat widget
- All new strings i18n'd (EN + VI)

## Test plan
- [ ] Start Agent BE + Hub BE + Hub FE
- [ ] Run `alembic upgrade head` to apply migration
- [ ] Open chat without API key → should show no-key view with help link
- [ ] Add valid API key in Settings → should validate and save successfully
- [ ] Open chat with key configured → should work normally with streaming
- [ ] Add invalid key → should show validation error
- [ ] Delete key → no-key view should return
- [ ] Switch language EN/VI → all chat/settings strings should be localized

🤖 Generated with [Claude Code](https://claude.com/claude-code)