### PR TITLE
Fix: handle limit_reached SSE event in Hub FE chat

### DIFF
--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -156,6 +156,13 @@ export function useChat() {
               }
               break;
             }
+            case 'limit_reached':
+              fullContent = t('chat.limit_reached');
+              answerContent = t('chat.limit_reached');
+              if (active) {
+                useChatStore.getState().setStreamingContent(t('chat.limit_reached'));
+              }
+              break;
             case 'error':
               if (active) {
                 const errorKey = mapSSEError(event.content || '');

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -975,6 +975,7 @@
     "error_rate_limited": "API rate limit exceeded. Please try again later.",
     "error_timeout": "Request timed out. Please try again.",
     "error_connection": "Cannot connect to AI service. Please try again later.",
-    "error_stream": "An error occurred. Please try again."
+    "error_stream": "An error occurred. Please try again.",
+    "limit_reached": "Hmm, your request is more complex than I expected 😔. I can't process it right now, please try again later!"
   }
 }

--- a/frontend/src/i18n/locales/vi.json
+++ b/frontend/src/i18n/locales/vi.json
@@ -969,6 +969,7 @@
     "error_rate_limited": "Đã vượt giới hạn gọi API. Vui lòng thử lại sau.",
     "error_timeout": "Yêu cầu quá thời gian. Vui lòng thử lại.",
     "error_connection": "Không kết nối được đến dịch vụ AI. Vui lòng thử lại sau.",
-    "error_stream": "Đã xảy ra lỗi. Vui lòng thử lại."
+    "error_stream": "Đã xảy ra lỗi. Vui lòng thử lại.",
+    "limit_reached": "Hmm, yêu cầu của bạn phức tạp hơn tôi tưởng 😔. Hiện tại tôi chưa thể giải quyết được, bạn thử lại sau nhé!"
   }
 }

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -13,7 +13,7 @@ export interface ChatMessage {
   created_at: string;
 }
 
-export type StreamEventType = 'token' | 'tool_call' | 'tool_result' | 'sources' | 'done' | 'error';
+export type StreamEventType = 'token' | 'tool_call' | 'tool_result' | 'sources' | 'done' | 'error' | 'limit_reached';
 
 export interface StreamEvent {
   type: StreamEventType;


### PR DESCRIPTION
## Summary
- Add `limit_reached` handler in `useChat.ts` to display friendly i18n message when LangGraph hits recursion limit
- Add `limit_reached` to `StreamEventType` union type
- Add `chat.limit_reached` translation key (Vietnamese + English)

## Problem
When Agent BE emits a `limit_reached` event (LangGraph recursion limit hit), the Hub FE had no handler for it — the switch statement fell through, `answerContent` stayed empty, resulting in an empty chat bubble.

## Files changed
- `frontend/src/hooks/useChat.ts` — add `limit_reached` case in switch
- `frontend/src/types/chat.ts` — add `limit_reached` to StreamEventType
- `frontend/src/i18n/locales/vi.json` — add `chat.limit_reached`
- `frontend/src/i18n/locales/en.json` — add `chat.limit_reached`

## Test plan
- [x] Docker build succeeds (TypeScript compiles)
- [x] Hub FE shows "Hmm, yêu cầu của bạn phức tạp hơn tôi tưởng 😔..." when limit reached
- [ ] Normal chat still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)